### PR TITLE
Render GPT responses with Markdown formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ config.json
 /dist/
 /build/
 /history.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ This shit is a mess and probably has a lot of unmaintanable code. Some parts wer
 
 Copy `config.example.json` to `config.json` and fill in the required secrets. The Asana integration now reads assignee options, priority field IDs, and any default custom fields directly from this file so you can tailor the app to your workspace without editing Python code.
 
+## Vendored dependencies
+
+The project vendors lightweight, offline-friendly replacements for the Markdown renderer and HTML display widget the UI relies on:
+
+* `markdown` – provides `markdown.markdown()` and `markdown.to_plain_text()` for turning model responses into HTML or plain text.
+* `tkhtmlview` – exposes `HTMLScrolledText`, a `tkinter` widget capable of displaying the rendered HTML output.
+
+Both packages live under the `vendor/` directory and are automatically added to `sys.path` at runtime.
+
 ## Screenshots
 
 **Main Window**

--- a/debug.py
+++ b/debug.py
@@ -1,10 +1,15 @@
 import datetime
-import openai
-import asana
-from asana.rest import ApiException
-from pprint import pprint
-import os
 import json
+import os
+from pprint import pprint
+
+from vendor_setup import ensure_vendor_path
+
+ensure_vendor_path()
+
+import asana
+import openai
+from asana.rest import ApiException
 
 # Load Config
 print("INFO: Loading Config File")

--- a/functions/database.py
+++ b/functions/database.py
@@ -3,6 +3,8 @@ import sqlite3
 from datetime import datetime
 import tkinter as tk
 
+import functions.ui
+
 # Database Path
 DB_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "history.db"))
 
@@ -54,7 +56,4 @@ def load_history_entry(entry_id, input_text, output_text):
     if row:
         input_text.delete("1.0", tk.END)
         input_text.insert(tk.END, row[0])
-        output_text.config(state="normal")
-        output_text.delete("1.0", tk.END)
-        output_text.insert(tk.END, row[1])
-        output_text.config(state="normal")
+        functions.ui.display_markdown(output_text, row[1] or "")

--- a/functions/database.py
+++ b/functions/database.py
@@ -26,10 +26,11 @@ def init_history_db():
 def save_to_history(mode, tone, email_text, response):
     conn = sqlite3.connect(DB_PATH)
     c = conn.cursor()
+    cleaned_response = functions.ui.normalize_markdown_spacing(response or "")
     c.execute('''
             INSERT INTO history (timestamp, mode, tone, input, output)
             VALUES (?, ?, ?, ?, ?)
-        ''', (datetime.now().isoformat(), mode, tone, email_text, response))
+        ''', (datetime.now().isoformat(), mode, tone, email_text, cleaned_response))
     conn.commit()
     conn.close()
 

--- a/functions/gpt.py
+++ b/functions/gpt.py
@@ -15,6 +15,8 @@ def custom_prompt(input_text,
     if include_email_checkbox_var.get():
         prompt += f"\n\nHere is the message for context:\n{email_text}"
 
+    prompt += "\n\nPlease respond using Markdown formatting."
+
     threading.Thread(target=call_openai, args=(prompt, output_text)).start()
 
 def draft_reply(tone_var,
@@ -27,7 +29,11 @@ def draft_reply(tone_var,
     email_text = input_text.get("1.0", tk.END).strip()
     if not email_text:
         return
-    prompt = f"Draft a {draft_length} {tone.lower()} reply to this email:\n\n{email_text}\n\nDont provide a response, subject or signature, only give the draft reply"
+    prompt = (
+        f"Draft a {draft_length} {tone.lower()} reply to this email:\n\n{email_text}\n\n"
+        "Dont provide a response, subject or signature, only give the draft reply."
+        " Format the reply using Markdown with headings, bullet lists, and emphasis where appropriate."
+    )
     threading.Thread(target=call_openai, args=(prompt, output_text)).start()
 
 def summarize(input_text: str,
@@ -48,7 +54,10 @@ def summarize(input_text: str,
         document_text = extract_text_from_file(attached_file_path)
         print("INFO: Appending attached document content")
 
-    prompt = f"Summarize the following message:\n\n{email_text}"
+    prompt = (
+        f"Summarize the following message:\n\n{email_text}\n\n"
+        "Present the summary as Markdown with clear headings and bullet lists when useful."
+    )
     if document_text:
         prompt += f"\nAlso summarize the following document:\n\n{document_text}"
     if task_checkbox_var.get():
@@ -79,6 +88,7 @@ def draft_invoice_note(input_text: str,
         "[Single sentence summary]\n"
         "[Date in DD/MM/YYYY]\n"
         "[Dotted notes]\n\n"
+        "Respond using Markdown.\n\n"
         f"Invoicing Notes: {job_title}\n"
         f"{input_text}"
     )

--- a/functions/ui.py
+++ b/functions/ui.py
@@ -1,9 +1,19 @@
+from __future__ import annotations
+
 import os
 import tkinter as tk
 from tkinter import messagebox
+from typing import Any
+
 from docx import Document
 
 import PyPDF2
+
+from vendor_setup import ensure_vendor_path
+
+ensure_vendor_path()
+
+import markdown
 
 
 def get_date(cal_var):
@@ -14,5 +24,42 @@ def get_date(cal_var):
 def copy_output(tk_root, output_text):
     print("INFO: Copied Output to Clipboard")
     tk_root.clipboard_clear()
-    tk_root.clipboard_append(output_text.get("1.0", tk.END).strip())
+    markdown_text = get_widget_markdown(output_text)
+    tk_root.clipboard_append(markdown_text)
     messagebox.showinfo("Copied", "Output copied to clipboard.")
+
+
+def get_widget_markdown(output_widget: Any) -> str:
+    """Return the raw Markdown stored on an output widget."""
+
+    raw_value = getattr(output_widget, "raw_markdown", None)
+    if isinstance(raw_value, str):
+        return raw_value.strip()
+    try:
+        return output_widget.get("1.0", tk.END).strip()
+    except Exception:  # pragma: no cover - fallback for unexpected widgets
+        return ""
+
+
+def display_markdown(output_widget: Any, markdown_text: str) -> None:
+    """Render Markdown inside an output widget and cache the raw text."""
+
+    setattr(output_widget, "raw_markdown", markdown_text)
+    html_text = markdown.markdown(markdown_text)
+    if hasattr(output_widget, "set_html"):
+        output_widget.set_html(html_text)
+    else:  # pragma: no cover - compatibility fallback
+        try:
+            output_widget.config(state=tk.NORMAL)
+            output_widget.delete("1.0", tk.END)
+            output_widget.insert(tk.END, markdown_text)
+        except Exception:
+            pass
+
+
+def markdown_to_plain_text(markdown_text: str) -> str:
+    """Convert Markdown to plain text for clipboard and API payloads."""
+
+    if not markdown_text:
+        return ""
+    return markdown.to_plain_text(markdown_text)

--- a/gui/invoice_window.py
+++ b/gui/invoice_window.py
@@ -5,7 +5,6 @@ from vendor_setup import ensure_vendor_path
 
 ensure_vendor_path()
 
-import markdown
 from openai import OpenAIError
 from tkhtmlview import HTMLScrolledText
 
@@ -110,9 +109,7 @@ def create_invoice_window(root, openai_service, config, show_main_callback):
     def call_openai(prompt: str, output_widget: HTMLScrolledText) -> None:
         try:
             reply = openai_service.generate_response(model_list_var.get(), prompt)
-            output_widget.config(state=tk.NORMAL)
-            output_widget.raw_markdown = reply
-            output_widget.set_html(markdown.markdown(reply))
+            functions.ui.display_markdown(output_widget, reply)
         except OpenAIError as exc:
             messagebox.showerror("OpenAI Error", str(exc))
         except Exception as exc:  # pragma: no cover - defensive programming

--- a/gui/invoice_window.py
+++ b/gui/invoice_window.py
@@ -1,7 +1,13 @@
 import tkinter as tk
-from tkinter import filedialog, messagebox, scrolledtext, ttk
+from tkinter import messagebox, scrolledtext, ttk
 
+from vendor_setup import ensure_vendor_path
+
+ensure_vendor_path()
+
+import markdown
 from openai import OpenAIError
+from tkhtmlview import HTMLScrolledText
 
 import functions.database
 import functions.gpt
@@ -39,7 +45,8 @@ def create_invoice_window(root, openai_service, config, show_main_callback):
     input_text = scrolledtext.ScrolledText(invoice_window, height=4, wrap=tk.WORD)
     input_text.pack(fill=tk.BOTH, padx=6, pady=5, expand=True)
 
-    output_text = scrolledtext.ScrolledText(invoice_window, height=5, wrap=tk.WORD)
+    output_label = tk.Label(invoice_window, text="Invoice Assistant Output:")
+    output_text = HTMLScrolledText(invoice_window, height=5)
 
     button_frame_main = tk.Frame(invoice_window)
     button_frame_main.pack()
@@ -100,14 +107,12 @@ def create_invoice_window(root, openai_service, config, show_main_callback):
 
     # include_invoice_checkbox_var = tk.BooleanVar()
 
-    attached_file_path = None
-
-    def call_openai(prompt: str, output_widget: tk.Text) -> None:
+    def call_openai(prompt: str, output_widget: HTMLScrolledText) -> None:
         try:
             reply = openai_service.generate_response(model_list_var.get(), prompt)
             output_widget.config(state=tk.NORMAL)
-            output_widget.delete("1.0", tk.END)
-            output_widget.insert(tk.END, reply)
+            output_widget.raw_markdown = reply
+            output_widget.set_html(markdown.markdown(reply))
         except OpenAIError as exc:
             messagebox.showerror("OpenAI Error", str(exc))
         except Exception as exc:  # pragma: no cover - defensive programming
@@ -153,7 +158,6 @@ def create_invoice_window(root, openai_service, config, show_main_callback):
     )
     back_button.grid(row=0, column=1, padx=5)
 
-    output_label = tk.Label(invoice_window, text="Invoice Assistant Output:")
     output_label.pack()
 
     output_text.pack(fill=tk.BOTH, padx=6, pady=5, expand=True)

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -6,7 +6,6 @@ from vendor_setup import ensure_vendor_path
 
 ensure_vendor_path()
 
-import markdown
 from openai import OpenAIError
 from tkcalendar import DateEntry
 from tkhtmlview import HTMLScrolledText
@@ -200,9 +199,7 @@ def create_main_window(openai_service, config: dict) -> None:
             reply = openai_service.generate_response(model_list_var.get(), prompt)
             print("INFO: Saving to local history")
             functions.database.save_to_history(mode, tone_var.get(), prompt, reply)
-            output_widget.config(state=tk.NORMAL)
-            output_widget.raw_markdown = reply
-            output_widget.set_html(markdown.markdown(reply))
+            functions.ui.display_markdown(output_widget, reply)
         except OpenAIError as e:
             messagebox.showerror("OpenAI Error", str(e))
         except Exception as e:

--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
 import json
 import os
 
+from vendor_setup import ensure_vendor_path
+
+ensure_vendor_path()
+
 from gui.main_window import create_main_window
 from services.openai_service import OpenAIService
 

--- a/vendor/__init__.py
+++ b/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored third-party style helpers used by the application."""

--- a/vendor/markdown/__init__.py
+++ b/vendor/markdown/__init__.py
@@ -1,0 +1,197 @@
+"""A very small Markdown to HTML renderer for offline environments.
+
+The implementation supports the subset of Markdown required by the assistant
+(headings, paragraphs, emphasis, inline code and unordered/ordered lists).
+It mirrors the ``markdown`` package's ``markdown`` function so that the rest
+of the application can treat it as a drop-in replacement.
+"""
+from __future__ import annotations
+
+import html
+import re
+from html.parser import HTMLParser
+from typing import List
+
+__all__ = ["markdown", "to_plain_text"]
+
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*)$")
+_BULLET_RE = re.compile(r"^[-*]\s+(.*)$")
+_ORDERED_RE = re.compile(r"^(\d+)[\.)]\s+(.*)$")
+
+
+def _apply_inline_markup(text: str) -> str:
+    """Apply inline Markdown transformations to *text* and return HTML."""
+
+    escaped = html.escape(text, quote=False)
+
+    def replace(pattern: str, repl: str, value: str) -> str:
+        return re.sub(pattern, repl, value, flags=re.MULTILINE)
+
+    # Bold (**text** or __text__)
+    escaped = replace(r"\*\*(.+?)\*\*", r"<strong>\1</strong>", escaped)
+    escaped = replace(r"__(.+?)__", r"<strong>\1</strong>", escaped)
+    # Italic (*text* or _text_). Tempered patterns avoid swallowing the bold
+    # markers themselves.
+    escaped = replace(r"(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)", r"<em>\1</em>", escaped)
+    escaped = replace(r"(?<!_)_(?!_)(.+?)(?<!_)_(?!_)", r"<em>\1</em>", escaped)
+    # Inline code (`code`).
+    escaped = replace(r"`(.+?)`", lambda match: f"<code>{match.group(1)}</code>", escaped)
+    return escaped
+
+
+def markdown(text: str) -> str:
+    """Convert Markdown *text* into HTML.
+
+    Only a limited subset of Markdown is supported. The function focuses on
+    clarity and predictable output for the UI rather than strict Markdown
+    compliance.
+    """
+
+    lines = text.splitlines()
+    blocks: List[str] = []
+    paragraph_lines: List[str] = []
+    list_type: str | None = None
+
+    def flush_paragraph() -> None:
+        nonlocal paragraph_lines
+        if not paragraph_lines:
+            return
+        paragraph_raw = "\n".join(paragraph_lines)
+        paragraph_html = _apply_inline_markup(paragraph_raw).replace("\n", "<br />")
+        blocks.append(f"<p>{paragraph_html}</p>")
+        paragraph_lines = []
+
+    def close_list() -> None:
+        nonlocal list_type
+        if list_type:
+            blocks.append(f"</{list_type}>")
+            list_type = None
+
+    for raw_line in lines:
+        stripped = raw_line.strip()
+        if not stripped:
+            flush_paragraph()
+            close_list()
+            continue
+
+        heading_match = _HEADING_RE.match(stripped)
+        if heading_match:
+            flush_paragraph()
+            close_list()
+            level = len(heading_match.group(1))
+            content = _apply_inline_markup(heading_match.group(2).strip())
+            blocks.append(f"<h{level}>{content}</h{level}>")
+            continue
+
+        bullet_match = _BULLET_RE.match(stripped)
+        if bullet_match:
+            flush_paragraph()
+            if list_type not in {"ul"}:
+                close_list()
+                list_type = "ul"
+                blocks.append("<ul>")
+            content = _apply_inline_markup(bullet_match.group(1).strip())
+            blocks.append(f"<li>{content}</li>")
+            continue
+
+        ordered_match = _ORDERED_RE.match(stripped)
+        if ordered_match:
+            flush_paragraph()
+            if list_type not in {"ol"}:
+                close_list()
+                list_type = "ol"
+                blocks.append("<ol>")
+            content = _apply_inline_markup(ordered_match.group(2).strip())
+            blocks.append(f"<li>{content}</li>")
+            continue
+
+        close_list()
+        paragraph_lines.append(stripped)
+
+    flush_paragraph()
+    close_list()
+
+    return "\n".join(blocks)
+
+
+class _PlainTextExtractor(HTMLParser):
+    """Convert the HTML produced by :func:`markdown` into plain text."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._parts: List[str] = []
+        self._list_stack: List[dict[str, int]] = []
+
+    # -- Helpers ---------------------------------------------------------
+    def _append_newline(self, count: int = 1) -> None:
+        if not self._parts:
+            return
+        # Prevent runaway blank lines by ensuring at most two consecutive ones.
+        trailing = 0
+        for chunk in reversed(self._parts):
+            if chunk.endswith("\n"):
+                trailing += chunk.count("\n")
+                if trailing >= count:
+                    return
+            else:
+                break
+        self._parts.append("\n" * count)
+
+    # -- HTMLParser API --------------------------------------------------
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        if tag in {"p", "div", "h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._append_newline()
+        elif tag == "br":
+            self._parts.append("\n")
+        elif tag == "ul":
+            self._list_stack.append({"type": "ul", "index": 0})
+        elif tag == "ol":
+            self._list_stack.append({"type": "ol", "index": 0})
+        elif tag == "li":
+            self._append_newline()
+            if self._list_stack:
+                current = self._list_stack[-1]
+                if current["type"] == "ul":
+                    self._parts.append("- ")
+                else:
+                    current["index"] += 1
+                    self._parts.append(f"{current['index']}. ")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"p", "div", "li", "h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._append_newline()
+        elif tag in {"ul", "ol"}:
+            if self._list_stack:
+                self._list_stack.pop()
+            self._append_newline()
+
+    def handle_data(self, data: str) -> None:
+        if data:
+            self._parts.append(data)
+
+    # -- Public API ------------------------------------------------------
+    def get_text(self) -> str:
+        joined = "".join(self._parts)
+        lines = [line.rstrip() for line in joined.splitlines()]
+        cleaned: List[str] = []
+        previous_blank = True
+        for line in lines:
+            if line:
+                cleaned.append(line)
+                previous_blank = False
+            else:
+                if not previous_blank:
+                    cleaned.append("")
+                previous_blank = True
+        while cleaned and not cleaned[-1]:
+            cleaned.pop()
+        return "\n".join(cleaned)
+
+
+def to_plain_text(text: str) -> str:
+    """Return a plain-text representation of the supplied Markdown string."""
+
+    extractor = _PlainTextExtractor()
+    extractor.feed(markdown(text))
+    extractor.close()
+    return extractor.get_text()

--- a/vendor/tkhtmlview/__init__.py
+++ b/vendor/tkhtmlview/__init__.py
@@ -1,0 +1,170 @@
+"""A lightweight HTML display widget built on top of ``tkinter``.
+
+The implementation mirrors the subset of the ``tkhtmlview`` API that the
+assistant relies on (currently only :class:`HTMLScrolledText` with a
+``set_html`` method).
+"""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import scrolledtext
+from tkinter import font as tkfont
+from html.parser import HTMLParser
+from typing import List
+
+__all__ = ["HTMLScrolledText"]
+
+
+class _HTMLRenderer(HTMLParser):
+    """Render a restricted HTML subset into a ``tk.Text`` widget."""
+
+    def __init__(self, widget: tk.Text) -> None:
+        super().__init__(convert_charrefs=True)
+        self.widget = widget
+        self.inline_tags: List[str] = []
+        self.list_stack: List[dict[str, int]] = []
+        self._pending_newlines = 0
+        self._text_written = False
+
+    # -- Helpers ---------------------------------------------------------
+    def _queue_newlines(self, count: int) -> None:
+        if self._text_written:
+            self._pending_newlines = max(self._pending_newlines, count)
+
+    def _flush_newlines(self) -> None:
+        if self._pending_newlines:
+            self.widget.insert(tk.END, "\n" * self._pending_newlines)
+            self._pending_newlines = 0
+            self._text_written = True
+
+    def _pop_inline_tag(self, name: str) -> None:
+        for index in range(len(self.inline_tags) - 1, -1, -1):
+            if self.inline_tags[index] == name:
+                self.inline_tags.pop(index)
+                break
+
+    # -- HTMLParser API --------------------------------------------------
+    def handle_starttag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        if tag in {"p", "div"}:
+            self._queue_newlines(1)
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._queue_newlines(2)
+            self.inline_tags.append(tag)
+        elif tag == "br":
+            self._queue_newlines(1)
+            self._flush_newlines()
+        elif tag == "ul":
+            self._queue_newlines(1)
+            self.list_stack.append({"type": "ul", "index": 0})
+        elif tag == "ol":
+            self._queue_newlines(1)
+            self.list_stack.append({"type": "ol", "index": 0})
+        elif tag == "li":
+            self._queue_newlines(1)
+            self._flush_newlines()
+            bullet = "• "
+            if self.list_stack:
+                current = self.list_stack[-1]
+                if current["type"] == "ol":
+                    current["index"] += 1
+                    bullet = f"{current['index']}. "
+            self.widget.insert(tk.END, bullet)
+            self._text_written = True
+        elif tag in {"strong", "b"}:
+            self.inline_tags.append("bold")
+        elif tag in {"em", "i"}:
+            self.inline_tags.append("italic")
+        elif tag == "code":
+            self.inline_tags.append("code")
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in {"p", "div"}:
+            self._queue_newlines(1)
+        elif tag in {"h1", "h2", "h3", "h4", "h5", "h6"}:
+            self._pop_inline_tag(tag)
+            self._queue_newlines(2)
+        elif tag == "li":
+            self._queue_newlines(1)
+        elif tag == "ul":
+            if self.list_stack:
+                self.list_stack.pop()
+            self._queue_newlines(1)
+        elif tag == "ol":
+            if self.list_stack:
+                self.list_stack.pop()
+            self._queue_newlines(1)
+        elif tag in {"strong", "b"}:
+            self._pop_inline_tag("bold")
+        elif tag in {"em", "i"}:
+            self._pop_inline_tag("italic")
+        elif tag == "code":
+            self._pop_inline_tag("code")
+
+    def handle_startendtag(self, tag: str, attrs: List[tuple[str, str | None]]) -> None:
+        if tag == "br":
+            self._queue_newlines(1)
+            self._flush_newlines()
+
+    def handle_data(self, data: str) -> None:
+        if not data:
+            return
+        self._flush_newlines()
+        tags = tuple(self.inline_tags)
+        if tags:
+            self.widget.insert(tk.END, data, tags)
+        else:
+            self.widget.insert(tk.END, data)
+        self._text_written = True
+
+    def close(self) -> None:  # type: ignore[override]
+        super().close()
+        self._flush_newlines()
+
+
+class HTMLScrolledText(scrolledtext.ScrolledText):
+    """A ``ScrolledText`` widget that understands a subset of HTML."""
+
+    def __init__(self, master: tk.Misc | None = None, **kwargs) -> None:
+        kwargs.setdefault("wrap", tk.WORD)
+        super().__init__(master, **kwargs)
+        self.raw_markdown = ""
+        self._configure_tags()
+
+    # -- Tag configuration ------------------------------------------------
+    def _configure_tags(self) -> None:
+        base_font = tkfont.nametofont(self.cget("font")).copy()
+
+        bold_font = base_font.copy()
+        bold_font.configure(weight="bold")
+        self.tag_configure("bold", font=bold_font)
+
+        italic_font = base_font.copy()
+        italic_font.configure(slant="italic")
+        self.tag_configure("italic", font=italic_font)
+
+        code_font = base_font.copy()
+        code_font.configure(family="Courier", size=max(base_font["size"] - 1, 8))
+        self.tag_configure("code", font=code_font)
+
+        for level in range(1, 7):
+            heading_font = base_font.copy()
+            heading_font.configure(weight="bold", size=max(base_font["size"] + 6 - (level * 2), base_font["size"]))
+            self.tag_configure(f"h{level}", font=heading_font, spacing1=4, spacing3=4)
+
+    # -- Public API ------------------------------------------------------
+    def set_html(self, html_content: str) -> None:
+        """Render the supplied HTML string inside the widget."""
+
+        self.config(state=tk.NORMAL)
+        self.delete("1.0", tk.END)
+        renderer = _HTMLRenderer(self)
+        renderer.feed(html_content or "")
+        renderer.close()
+        self.see("1.0")
+
+    def clear(self) -> None:
+        """Convenience method to empty the widget."""
+
+        self.config(state=tk.NORMAL)
+        self.delete("1.0", tk.END)
+        self.raw_markdown = ""

--- a/vendor_setup.py
+++ b/vendor_setup.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import os
+import sys
+
+
+def ensure_vendor_path() -> None:
+    """Add the local ``vendor`` directory to ``sys.path`` if present."""
+    vendor_dir = os.path.join(os.path.dirname(__file__), "vendor")
+    if os.path.isdir(vendor_dir) and vendor_dir not in sys.path:
+        sys.path.insert(0, vendor_dir)


### PR DESCRIPTION
## Summary
- vendor lightweight markdown rendering and HTML display helpers and load them via a shared vendor bootstrap
- render main and invoice outputs with HTMLScrolledText widgets while storing raw Markdown for copy/export and Asana payloads
- update GPT prompt templates to request Markdown responses and document the new dependencies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68ccd6eaf0e48326a937acb13470106c