### PR TITLE
Add Hyprland-inspired ttk theme and modernize main/invoice GUIs

### DIFF
--- a/gui/invoice_window.py
+++ b/gui/invoice_window.py
@@ -13,6 +13,7 @@ import functions.database
 import functions.gpt
 import functions.ui
 from functions.files import extract_text_from_file
+from gui.theme import apply_hyprland_theme
 
 
 def create_invoice_window(
@@ -21,16 +22,17 @@ def create_invoice_window(
     """Build the invoice notes assistant window."""
 
     invoice_window = tk.Toplevel(root)
+    apply_hyprland_theme(invoice_window)
     window_title = "Invoice Notes Assistant"
     workspace = config.get("asana_workspace") if isinstance(config, dict) else None
     if workspace:
         window_title = f"{window_title} – {workspace}"
     invoice_window.title(window_title)
-    invoice_window.geometry("800x960")
+    invoice_window.geometry("900x980")
 
-    status_frame = tk.Frame(invoice_window)
+    status_frame = ttk.Frame(invoice_window, style="App.TFrame")
     status_frame.pack(fill="x", padx=10, pady=(0, 5))
-    status_label = tk.Label(status_frame, text="", anchor="w")
+    status_label = ttk.Label(status_frame, text="", anchor="w", style="Muted.TLabel")
     status_label.pack(side="left")
     progress_bar = ttk.Progressbar(status_frame, mode="indeterminate")
 
@@ -66,42 +68,41 @@ def create_invoice_window(
         model_list_var.set(model_choices[0])
 
     # Job Title
-    job_title_label = tk.Label(invoice_window, text="Enter Job Title:")
+    job_title_label = ttk.Label(invoice_window, text="Enter Job Title:", style="Header.TLabel")
     job_title_label.pack()
 
-    job_title = tk.Entry(invoice_window)
+    job_title = ttk.Entry(invoice_window)
     job_title.pack(fill="x", padx=45, pady=5)
 
     # Invoice Input
-    input_label = tk.Label(invoice_window, text="Paste Invoice Details Here:")
+    input_label = ttk.Label(invoice_window, text="Paste Invoice Details Here:", style="Header.TLabel")
     input_label.pack()
 
     input_text = scrolledtext.ScrolledText(invoice_window, height=4, wrap=tk.WORD)
     input_text.pack(fill="both", padx=6, pady=5, expand=True)
 
-    output_label = tk.Label(invoice_window, text="Invoice Assistant Output:")
+    output_label = ttk.Label(invoice_window, text="Invoice Assistant Output:", style="Header.TLabel")
     output_text = HTMLScrolledText(invoice_window, height=5)
     functions.ui.enable_html_clipboard_copy(invoice_window, output_text)
 
-    button_frame_main = tk.Frame(invoice_window)
+    button_frame_main = ttk.Frame(invoice_window, style="App.TFrame")
     button_frame_main.pack()
 
-    button_frame_left = tk.Frame(button_frame_main)
+    button_frame_left = ttk.Frame(button_frame_main, style="App.TFrame")
     button_frame_left.grid(column=0, row=0, padx=10)
-    button_frame_left_top = tk.Frame(button_frame_left, bd=1, relief="groove", pady=5)
+    button_frame_left_top = ttk.Frame(button_frame_left, style="Card.TFrame", padding=10)
     button_frame_left_top.pack(pady=5)
-    button_frame_left_bottom = tk.Frame(button_frame_left, bd=1, relief="groove", pady=5)
+    button_frame_left_bottom = ttk.Frame(button_frame_left, style="Card.TFrame", padding=10)
     button_frame_left_bottom.pack(pady=5)
 
-    button_frame_right = tk.Frame(button_frame_main)
+    button_frame_right = ttk.Frame(button_frame_main, style="App.TFrame")
     button_frame_right.grid(column=1, row=0, padx=10)
-    button_frame_right_top = tk.Frame(button_frame_right, bd=1, relief="groove", pady=5)
+    button_frame_right_top = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_top.pack(pady=5)
-    button_frame_right_bottom = tk.Frame(button_frame_right, bd=1, relief="groove", pady=5)
+    button_frame_right_bottom = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_bottom.pack(pady=5)
 
-    model_list_label = tk.Label(button_frame_right_top, text="Select GPT Model")
-    model_list_label.config(font=("Segoe UI", 9, "bold"))
+    model_list_label = ttk.Label(button_frame_right_top, text="Select GPT Model", style="Header.TLabel")
     model_list_label.grid(row=0, column=0, padx=5)
 
     model_list = ttk.OptionMenu(
@@ -125,7 +126,7 @@ def create_invoice_window(
     # )
     # note_style_menu.grid(row=0, column=1, padx=5)
 
-    checkbox_frame = tk.Frame(button_frame_right)
+    checkbox_frame = ttk.Frame(button_frame_right, style="App.TFrame")
     checkbox_frame.pack(pady=5)
 
     # prompt_frame = tk.Frame(invoice_window, bd=1, relief="groove")
@@ -163,9 +164,10 @@ def create_invoice_window(
         else:  # pragma: no cover - fallback for unexpected embedding contexts
             threading.Thread(target=worker, daemon=True).start()
 
-    create_notes_button = tk.Button(
+    create_notes_button = ttk.Button(
         button_frame_left_top,
         text="Summarise Invoice",
+        style="Primary.TButton",
         command=lambda: functions.gpt.draft_invoice_note(
             input_text.get("1.0", tk.END).strip(),
             job_title.get(),
@@ -189,14 +191,14 @@ def create_invoice_window(
     # )
     # prompt_button.grid(row=0, column=0, pady=5, padx=5)
 
-    copy_button = tk.Button(
+    copy_button = ttk.Button(
         button_frame_left_bottom,
         text="Copy Output",
         command=lambda: functions.ui.copy_output(invoice_window, output_text),
     )
     copy_button.grid(row=0, column=0, padx=5)
 
-    back_button = tk.Button(
+    back_button = ttk.Button(
         button_frame_left_bottom,
         text="Back to Email Assistant",
         command=show_main_callback,

--- a/gui/invoice_window.py
+++ b/gui/invoice_window.py
@@ -60,7 +60,7 @@ def create_invoice_window(
     model_choices = getattr(
         root,
         "shared_model_choices",
-        ["gpt-4", "gpt-4.1", "gpt-5", "o4-mini"],
+        ["o4-mini", "gpt-4", "gpt-4.1", "gpt-5", "gpt-5.4"],
     )
     if not isinstance(model_choices, list) or not model_choices:
         model_choices = ["gpt-4", "gpt-4.1", "gpt-5", "o4-mini"]
@@ -102,7 +102,11 @@ def create_invoice_window(
     button_frame_right_bottom = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_bottom.pack(pady=5)
 
-    model_list_label = ttk.Label(button_frame_right_top, text="Select GPT Model", style="Header.TLabel")
+    model_list_label = ttk.Label(
+        button_frame_right_top,
+        text="Select GPT Model",
+        style="Card.Header.TLabel",
+    )
     model_list_label.grid(row=0, column=0, padx=5)
 
     model_list = ttk.OptionMenu(

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -20,6 +20,7 @@ import functions.gpt
 import functions.ui
 from functions.files import extract_text_from_file
 from gui.invoice_window import create_invoice_window
+from gui.theme import apply_hyprland_theme
 
 # GUI ----------------------------------------------------------------
 
@@ -109,7 +110,8 @@ def create_main_window(openai_service, config: dict) -> None:
     # Root Window
     root = tk.Tk()
     root.title("ChatGPT Email Assistant")
-    root.geometry("800x960")
+    root.geometry("900x980")
+    apply_hyprland_theme(root)
 
     fallback_models = ["gpt-4", "gpt-4.1", "gpt-5", "o4-mini"]
     model_choices_raw = config.get("model_choices")
@@ -190,9 +192,9 @@ def create_main_window(openai_service, config: dict) -> None:
 
     loading_manager = LoadingIndicatorManager()
 
-    status_frame = tk.Frame(root)
+    status_frame = ttk.Frame(root, style="App.TFrame")
     status_frame.pack(fill="x", padx=10, pady=(0, 5))
-    status_label = tk.Label(status_frame, text="", anchor="w")
+    status_label = ttk.Label(status_frame, text="", anchor="w", style="Muted.TLabel")
     status_label.pack(side="left")
     progress_bar = ttk.Progressbar(status_frame, mode="indeterminate")
 
@@ -236,14 +238,14 @@ def create_main_window(openai_service, config: dict) -> None:
     scrolled_font.configure(size=10)
 
     # Email Input
-    input_label = tk.Label(root, text="Paste Email Content Here:")
+    input_label = ttk.Label(root, text="Paste Email Content Here:", style="Header.TLabel")
     input_label.pack()
 
     input_text = HTMLScrolledText(root, height=10, font=scrolled_font)
     input_text.pack(fill="both", padx=6, pady=5, expand=True)
     functions.ui.enable_html_clipboard_paste(input_text)
 
-    output_label = tk.Label(root, text="ChatGPT Output:")
+    output_label = ttk.Label(root, text="ChatGPT Output:", style="Header.TLabel")
     output_text = HTMLScrolledText(root, height=10, font=scrolled_font)
     functions.ui.enable_html_clipboard_copy(root, output_text)
 
@@ -264,25 +266,24 @@ def create_main_window(openai_service, config: dict) -> None:
     refresh_button.pack(side="left", padx=5)
 
     # Button Frames
-    button_frame_main = tk.Frame(root)
+    button_frame_main = ttk.Frame(root, style="App.TFrame")
     button_frame_main.pack()
 
-    button_frame_left = tk.Frame(button_frame_main)
+    button_frame_left = ttk.Frame(button_frame_main, style="App.TFrame")
     button_frame_left.grid(column=0, row=0, padx=10)
-    button_frame_left_top = tk.Frame(button_frame_left, bd=1, relief="groove", pady=5)
+    button_frame_left_top = ttk.Frame(button_frame_left, style="Card.TFrame", padding=10)
     button_frame_left_top.pack(pady=5)
-    button_frame_left_bottom = tk.Frame(button_frame_left, bd=1, relief="groove", pady=5)
+    button_frame_left_bottom = ttk.Frame(button_frame_left, style="Card.TFrame", padding=10)
     button_frame_left_bottom.pack(pady=10)
 
-    button_frame_right = tk.Frame(button_frame_main)
+    button_frame_right = ttk.Frame(button_frame_main, style="App.TFrame")
     button_frame_right.grid(column=1, row=0, padx=10)
-    button_frame_right_top = tk.Frame(button_frame_right, bd=1, relief="groove", pady=5)
+    button_frame_right_top = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_top.pack(pady=5)
-    button_frame_right_bottom = tk.Frame(button_frame_right, bd=1, relief="groove", pady=5)
+    button_frame_right_bottom = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_bottom.pack(pady=10)
 
-    model_list_label = tk.Label(button_frame_right_top, text="Select GPT Model")
-    model_list_label.config(font=("Segoe UI", 9, "bold"))
+    model_list_label = ttk.Label(button_frame_right_top, text="Select GPT Model", style="Header.TLabel")
     model_list_label.grid(row=0, column=0, padx=5)
 
     model_list = ttk.OptionMenu(
@@ -348,9 +349,10 @@ def create_main_window(openai_service, config: dict) -> None:
         invoice_window.lift()
 
     # Summarize content in the email field
-    summarize_button = tk.Button(
+    summarize_button = ttk.Button(
         button_frame_left_top,
         text="Summarise",
+        style="Primary.TButton",
         command=lambda: functions.gpt.summarize(
             input_text.get("1.0", tk.END).strip(),
             model_list_var.get(),
@@ -366,7 +368,7 @@ def create_main_window(openai_service, config: dict) -> None:
     summarize_button.grid(row=0, column=0, padx=5)
 
     # Draft response based on content in the email field
-    draft_button = tk.Button(
+    draft_button = ttk.Button(
         button_frame_left_top,
         text="Draft Reply",
         command=lambda: functions.gpt.draft_reply(
@@ -380,11 +382,11 @@ def create_main_window(openai_service, config: dict) -> None:
     draft_button.grid(row=0, column=1, padx=5)
 
     # Attach file button
-    attach_button = tk.Button(button_frame_left_top, text="Attach Document", command=attach_file)
+    attach_button = ttk.Button(button_frame_left_top, text="Attach Document", command=attach_file)
     attach_button.grid(row=0, column=2, padx=5)
 
     # Copy response text
-    copy_button = tk.Button(
+    copy_button = ttk.Button(
         button_frame_left_bottom,
         text="Copy Output",
         command=lambda: functions.ui.copy_output(root, output_text),
@@ -449,45 +451,45 @@ def create_main_window(openai_service, config: dict) -> None:
 
         run_with_loading("Creating Asana task…", worker)
 
-    asana_button = tk.Button(
+    asana_button = ttk.Button(
         button_frame_left_bottom,
         text="Add to Asana",
+        style="Primary.TButton",
         command=send_to_asana_with_loading,
     )
     asana_button.grid(row=1, column=1, padx=5)
 
-    invoice_button = tk.Button(
+    invoice_button = ttk.Button(
         button_frame_right_bottom,
         text="Switch to Invoicing Notes",
+        style="Primary.TButton",
         command=show_invoice_window,
     )
     invoice_button.grid(row=0, column=0, columnspan=2, padx=5, pady=(0, 5), sticky="ew")
 
-    options_frame = tk.Frame(root)
+    options_frame = ttk.Frame(root, style="App.TFrame")
     options_frame.pack()
 
-    draft_frame = tk.Frame(options_frame, bd=1, relief="groove")
+    draft_frame = ttk.Frame(options_frame, style="Card.TFrame", padding=10)
     draft_frame.grid(row=0, column=1)
 
-    tone_label = tk.Label(draft_frame, text="Select Tone for Drafted Reply:")
-    tone_label.config(font=("Segoe UI", 9, "bold"))
+    tone_label = ttk.Label(draft_frame, text="Select Tone for Drafted Reply:", style="Header.TLabel")
     tone_label.grid(row=0, column=1, padx=5)
 
     tone_menu = ttk.OptionMenu(draft_frame, tone_var, "Professional", "Professional", "Semi-professional", "Casual")
     tone_menu.grid(row=1, column=1, padx=5)
 
-    length_label = tk.Label(draft_frame, text="Select Length for Drafted Reply:")
-    length_label.config(font=("Segoe UI", 9, "bold"))
+    length_label = ttk.Label(draft_frame, text="Select Length for Drafted Reply:", style="Header.TLabel")
     length_label.grid(row=2, column=1, padx=5)
 
     length_menu = ttk.OptionMenu(draft_frame, length_var, "Short", "Short", "Medium", "Long")
     length_menu.grid(row=3, column=1, padx=5)
 
-    checkbox_frame = tk.Frame(options_frame, bd=1, relief="groove")
+    checkbox_frame = ttk.Frame(options_frame, style="Card.TFrame", padding=10)
     checkbox_frame.grid(row=0, column=2, padx=5)
 
     task_checkbox_var = tk.BooleanVar()
-    task_checkbox = tk.Checkbutton(
+    task_checkbox = ttk.Checkbutton(
         checkbox_frame,
         text="Include task list in summary?",
         variable=task_checkbox_var,
@@ -495,7 +497,7 @@ def create_main_window(openai_service, config: dict) -> None:
     task_checkbox.grid(row=1, column=0, padx=5)
 
     fixes_checkbox_var = tk.BooleanVar()
-    fixes_checkbox = tk.Checkbutton(
+    fixes_checkbox = ttk.Checkbutton(
         checkbox_frame,
         text="Provide possible solutions to issue?",
         variable=fixes_checkbox_var,
@@ -503,18 +505,17 @@ def create_main_window(openai_service, config: dict) -> None:
     fixes_checkbox.grid(row=2, column=0, padx=5)
 
     attached_file_checkbox_var = tk.BooleanVar()
-    attached_file_checkbox = tk.Checkbutton(
+    attached_file_checkbox = ttk.Checkbutton(
         checkbox_frame,
         text="Summarise attached document?",
         variable=attached_file_checkbox_var,
     )
     attached_file_checkbox.grid(row=3, column=0, padx=5)
 
-    assignee_frame = tk.Frame(options_frame, bd=1, relief="groove")
+    assignee_frame = ttk.Frame(options_frame, style="Card.TFrame", padding=10)
     assignee_frame.grid(row=0, column=3, padx=5)
 
-    assignee_label = tk.Label(assignee_frame, text="Assignee")
-    assignee_label.config(font=("Segoe UI", 9, "bold"))
+    assignee_label = ttk.Label(assignee_frame, text="Assignee", style="Header.TLabel")
     assignee_label.grid(row=0, column=0, padx=5)
 
     assignee_var = tk.StringVar(value=default_assignee)
@@ -527,15 +528,13 @@ def create_main_window(openai_service, config: dict) -> None:
     )
     assignee_menu.grid(row=1, column=0, padx=5)
 
-    cal_label = tk.Label(assignee_frame, text="Due Date")
-    cal_label.config(font=("Segoe UI", 9, "bold"))
+    cal_label = ttk.Label(assignee_frame, text="Due Date", style="Header.TLabel")
     cal_label.grid(row=0, column=1, padx=5)
 
     cal_var = DateEntry(assignee_frame, date_pattern="yyyy-mm-dd")
     cal_var.grid(row=1, column=1, padx=5)
 
-    priority_label = tk.Label(assignee_frame, text="Priority")
-    priority_label.config(font=("Segoe UI", 9, "bold"))
+    priority_label = ttk.Label(assignee_frame, text="Priority", style="Header.TLabel")
     priority_label.grid(row=2, column=0, padx=5)
 
     priority_var = tk.StringVar(value=default_priority)
@@ -548,22 +547,21 @@ def create_main_window(openai_service, config: dict) -> None:
     )
     priority_menu.grid(row=3, column=0, padx=5)
 
-    prompt_frame = tk.Frame(root, bd=1, relief="groove")
+    prompt_frame = ttk.Frame(root, style="Card.TFrame", padding=10)
     prompt_frame.pack(fill="x", padx=100, pady=5)
 
-    prompt_label = tk.Label(prompt_frame, text="Custom ChatGPT Prompt:")
-    prompt_label.config(font=("Segoe UI", 9, "bold"))
+    prompt_label = ttk.Label(prompt_frame, text="Custom ChatGPT Prompt:", style="Header.TLabel")
     prompt_label.pack()
 
-    prompt_entry = tk.Entry(prompt_frame)
+    prompt_entry = ttk.Entry(prompt_frame)
     prompt_entry.pack(fill="x", padx=5, pady=5)
 
-    prompt_button_frame = tk.Frame(prompt_frame)
+    prompt_button_frame = ttk.Frame(prompt_frame, style="Card.TFrame")
     prompt_button_frame.pack()
 
     include_email_checkbox_var = tk.BooleanVar()
 
-    prompt_button = tk.Button(
+    prompt_button = ttk.Button(
         prompt_button_frame,
         text="Custom Prompt",
         command=lambda: functions.gpt.custom_prompt(
@@ -576,7 +574,7 @@ def create_main_window(openai_service, config: dict) -> None:
     )
     prompt_button.grid(row=0, column=0, pady=5, padx=5)
 
-    include_email_checkbox = tk.Checkbutton(
+    include_email_checkbox = ttk.Checkbutton(
         prompt_button_frame,
         text="Include email for context?",
         variable=include_email_checkbox_var,

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -113,7 +113,7 @@ def create_main_window(openai_service, config: dict) -> None:
     root.geometry("900x980")
     apply_hyprland_theme(root)
 
-    fallback_models = ["gpt-4", "gpt-4.1", "gpt-5", "o4-mini"]
+    fallback_models = ["o4-mini", "gpt-4", "gpt-4.1", "gpt-5", "gpt-5.4"]
     model_choices_raw = config.get("model_choices")
     model_choices = (
         [entry for entry in model_choices_raw if isinstance(entry, str) and entry]
@@ -283,7 +283,11 @@ def create_main_window(openai_service, config: dict) -> None:
     button_frame_right_bottom = ttk.Frame(button_frame_right, style="Card.TFrame", padding=10)
     button_frame_right_bottom.pack(pady=10)
 
-    model_list_label = ttk.Label(button_frame_right_top, text="Select GPT Model", style="Header.TLabel")
+    model_list_label = ttk.Label(
+        button_frame_right_top,
+        text="Select GPT Model",
+        style="Card.Header.TLabel",
+    )
     model_list_label.grid(row=0, column=0, padx=5)
 
     model_list = ttk.OptionMenu(
@@ -473,13 +477,21 @@ def create_main_window(openai_service, config: dict) -> None:
     draft_frame = ttk.Frame(options_frame, style="Card.TFrame", padding=10)
     draft_frame.grid(row=0, column=1)
 
-    tone_label = ttk.Label(draft_frame, text="Select Tone for Drafted Reply:", style="Header.TLabel")
+    tone_label = ttk.Label(
+        draft_frame,
+        text="Select Tone for Drafted Reply:",
+        style="Card.Header.TLabel",
+    )
     tone_label.grid(row=0, column=1, padx=5)
 
     tone_menu = ttk.OptionMenu(draft_frame, tone_var, "Professional", "Professional", "Semi-professional", "Casual")
     tone_menu.grid(row=1, column=1, padx=5)
 
-    length_label = ttk.Label(draft_frame, text="Select Length for Drafted Reply:", style="Header.TLabel")
+    length_label = ttk.Label(
+        draft_frame,
+        text="Select Length for Drafted Reply:",
+        style="Card.Header.TLabel",
+    )
     length_label.grid(row=2, column=1, padx=5)
 
     length_menu = ttk.OptionMenu(draft_frame, length_var, "Short", "Short", "Medium", "Long")
@@ -493,6 +505,7 @@ def create_main_window(openai_service, config: dict) -> None:
         checkbox_frame,
         text="Include task list in summary?",
         variable=task_checkbox_var,
+        style="Card.TCheckbutton",
     )
     task_checkbox.grid(row=1, column=0, padx=5)
 
@@ -501,6 +514,7 @@ def create_main_window(openai_service, config: dict) -> None:
         checkbox_frame,
         text="Provide possible solutions to issue?",
         variable=fixes_checkbox_var,
+        style="Card.TCheckbutton",
     )
     fixes_checkbox.grid(row=2, column=0, padx=5)
 
@@ -509,13 +523,16 @@ def create_main_window(openai_service, config: dict) -> None:
         checkbox_frame,
         text="Summarise attached document?",
         variable=attached_file_checkbox_var,
+        style="Card.TCheckbutton",
     )
     attached_file_checkbox.grid(row=3, column=0, padx=5)
 
     assignee_frame = ttk.Frame(options_frame, style="Card.TFrame", padding=10)
     assignee_frame.grid(row=0, column=3, padx=5)
 
-    assignee_label = ttk.Label(assignee_frame, text="Assignee", style="Header.TLabel")
+    assignee_label = ttk.Label(
+        assignee_frame, text="Assignee", style="Card.Header.TLabel"
+    )
     assignee_label.grid(row=0, column=0, padx=5)
 
     assignee_var = tk.StringVar(value=default_assignee)
@@ -528,13 +545,17 @@ def create_main_window(openai_service, config: dict) -> None:
     )
     assignee_menu.grid(row=1, column=0, padx=5)
 
-    cal_label = ttk.Label(assignee_frame, text="Due Date", style="Header.TLabel")
+    cal_label = ttk.Label(
+        assignee_frame, text="Due Date", style="Card.Header.TLabel"
+    )
     cal_label.grid(row=0, column=1, padx=5)
 
     cal_var = DateEntry(assignee_frame, date_pattern="yyyy-mm-dd")
     cal_var.grid(row=1, column=1, padx=5)
 
-    priority_label = ttk.Label(assignee_frame, text="Priority", style="Header.TLabel")
+    priority_label = ttk.Label(
+        assignee_frame, text="Priority", style="Card.Header.TLabel"
+    )
     priority_label.grid(row=2, column=0, padx=5)
 
     priority_var = tk.StringVar(value=default_priority)
@@ -550,7 +571,11 @@ def create_main_window(openai_service, config: dict) -> None:
     prompt_frame = ttk.Frame(root, style="Card.TFrame", padding=10)
     prompt_frame.pack(fill="x", padx=100, pady=5)
 
-    prompt_label = ttk.Label(prompt_frame, text="Custom ChatGPT Prompt:", style="Header.TLabel")
+    prompt_label = ttk.Label(
+        prompt_frame,
+        text="Custom ChatGPT Prompt:",
+        style="Card.Header.TLabel",
+    )
     prompt_label.pack()
 
     prompt_entry = ttk.Entry(prompt_frame)
@@ -578,6 +603,7 @@ def create_main_window(openai_service, config: dict) -> None:
         prompt_button_frame,
         text="Include email for context?",
         variable=include_email_checkbox_var,
+        style="Card.TCheckbutton",
     )
     include_email_checkbox.grid(row=0, column=2, pady=5, padx=5)
 

--- a/gui/theme.py
+++ b/gui/theme.py
@@ -1,4 +1,5 @@
 import tkinter as tk
+import tkinter.font as tkfont
 from tkinter import ttk
 
 # Hyprland-inspired dark palette with cool accents.
@@ -17,7 +18,7 @@ FONT_FAMILY = "Segoe UI"
 
 def _configure_classic_tk_defaults(root: tk.Misc) -> None:
     """Style classic tk widgets so they blend with ttk components."""
-    root.option_add("*Font", f"{FONT_FAMILY} 10")
+    root.option_add("*Font", "{Segoe UI} 10")
     root.option_add("*Background", BG_PRIMARY)
     root.option_add("*Foreground", TEXT_PRIMARY)
 
@@ -42,8 +43,26 @@ def _configure_classic_tk_defaults(root: tk.Misc) -> None:
     root.option_add("*Checkbutton.ActiveForeground", TEXT_PRIMARY)
 
 
+def _build_theme_fonts(root: tk.Misc) -> tuple[tkfont.Font, tkfont.Font, tkfont.Font, tkfont.Font]:
+    """Create named fonts to avoid Tcl parsing issues with font families that contain spaces."""
+    default_font = tkfont.nametofont("TkDefaultFont").copy()
+    default_font.configure(family=FONT_FAMILY, size=10)
+
+    header_font = default_font.copy()
+    header_font.configure(weight="bold")
+
+    muted_font = default_font.copy()
+    muted_font.configure(size=9)
+
+    primary_button_font = default_font.copy()
+    primary_button_font.configure(weight="bold")
+
+    return default_font, header_font, muted_font, primary_button_font
+
+
 def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
     style = ttk.Style(root)
+    default_font, header_font, muted_font, primary_button_font = _build_theme_fonts(root)
 
     preferred_themes = ("vista", "clam", "alt", "default")
     available = style.theme_names()
@@ -58,7 +77,7 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
         foreground=TEXT_PRIMARY,
         fieldbackground=BG_SECONDARY,
         bordercolor=BORDER,
-        font=(FONT_FAMILY, 10),
+        font=default_font,
     )
 
     style.configure("App.TFrame", background=BG_PRIMARY)
@@ -68,13 +87,13 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
         "Header.TLabel",
         background=BG_PRIMARY,
         foreground=TEXT_PRIMARY,
-        font=(FONT_FAMILY, 10, "bold"),
+        font=header_font,
     )
     style.configure(
         "Muted.TLabel",
         background=BG_PRIMARY,
         foreground=TEXT_MUTED,
-        font=(FONT_FAMILY, 9),
+        font=muted_font,
     )
 
     style.configure(
@@ -98,7 +117,7 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
         padding=8,
         relief="flat",
         borderwidth=0,
-        font=(FONT_FAMILY, 10, "bold"),
+        font=primary_button_font,
     )
     style.map(
         "Primary.TButton",

--- a/gui/theme.py
+++ b/gui/theme.py
@@ -1,0 +1,139 @@
+import tkinter as tk
+from tkinter import ttk
+
+# Hyprland-inspired dark palette with cool accents.
+BG_PRIMARY = "#11111B"
+BG_SECONDARY = "#181825"
+BG_ELEVATED = "#1E1E2E"
+BORDER = "#313244"
+TEXT_PRIMARY = "#CDD6F4"
+TEXT_MUTED = "#A6ADC8"
+ACCENT = "#89B4FA"
+ACCENT_ACTIVE = "#74C7EC"
+SUCCESS = "#A6E3A1"
+
+FONT_FAMILY = "Segoe UI"
+
+
+def _configure_classic_tk_defaults(root: tk.Misc) -> None:
+    """Style classic tk widgets so they blend with ttk components."""
+    root.option_add("*Font", f"{FONT_FAMILY} 10")
+    root.option_add("*Background", BG_PRIMARY)
+    root.option_add("*Foreground", TEXT_PRIMARY)
+
+    # Input/readable widgets
+    root.option_add("*Entry.Background", BG_SECONDARY)
+    root.option_add("*Entry.Foreground", TEXT_PRIMARY)
+    root.option_add("*Entry.InsertBackground", TEXT_PRIMARY)
+
+    root.option_add("*Text.Background", BG_SECONDARY)
+    root.option_add("*Text.Foreground", TEXT_PRIMARY)
+    root.option_add("*Text.InsertBackground", TEXT_PRIMARY)
+
+    # Buttons and checkboxes
+    root.option_add("*Button.Background", BG_ELEVATED)
+    root.option_add("*Button.Foreground", TEXT_PRIMARY)
+    root.option_add("*Button.ActiveBackground", BORDER)
+    root.option_add("*Button.ActiveForeground", TEXT_PRIMARY)
+
+    root.option_add("*Checkbutton.Background", BG_PRIMARY)
+    root.option_add("*Checkbutton.Foreground", TEXT_PRIMARY)
+    root.option_add("*Checkbutton.ActiveBackground", BG_PRIMARY)
+    root.option_add("*Checkbutton.ActiveForeground", TEXT_PRIMARY)
+
+
+def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
+    style = ttk.Style(root)
+
+    preferred_themes = ("vista", "clam", "alt", "default")
+    available = style.theme_names()
+    for theme in preferred_themes:
+        if theme in available:
+            style.theme_use(theme)
+            break
+
+    style.configure(
+        ".",
+        background=BG_PRIMARY,
+        foreground=TEXT_PRIMARY,
+        fieldbackground=BG_SECONDARY,
+        bordercolor=BORDER,
+        font=(FONT_FAMILY, 10),
+    )
+
+    style.configure("App.TFrame", background=BG_PRIMARY)
+    style.configure("Card.TFrame", background=BG_ELEVATED, relief="flat")
+
+    style.configure(
+        "Header.TLabel",
+        background=BG_PRIMARY,
+        foreground=TEXT_PRIMARY,
+        font=(FONT_FAMILY, 10, "bold"),
+    )
+    style.configure(
+        "Muted.TLabel",
+        background=BG_PRIMARY,
+        foreground=TEXT_MUTED,
+        font=(FONT_FAMILY, 9),
+    )
+
+    style.configure(
+        "TButton",
+        background=BG_ELEVATED,
+        foreground=TEXT_PRIMARY,
+        padding=8,
+        relief="flat",
+        borderwidth=0,
+    )
+    style.map(
+        "TButton",
+        background=[("active", BORDER), ("pressed", BORDER)],
+        foreground=[("disabled", TEXT_MUTED)],
+    )
+
+    style.configure(
+        "Primary.TButton",
+        background=ACCENT,
+        foreground=BG_PRIMARY,
+        padding=8,
+        relief="flat",
+        borderwidth=0,
+        font=(FONT_FAMILY, 10, "bold"),
+    )
+    style.map(
+        "Primary.TButton",
+        background=[("active", ACCENT_ACTIVE), ("pressed", ACCENT_ACTIVE)],
+        foreground=[("disabled", TEXT_MUTED)],
+    )
+
+    style.configure("TMenubutton", background=BG_ELEVATED, foreground=TEXT_PRIMARY)
+    style.map("TMenubutton", background=[("active", BORDER)])
+
+    style.configure(
+        "TCheckbutton",
+        background=BG_PRIMARY,
+        foreground=TEXT_PRIMARY,
+    )
+    style.map("TCheckbutton", background=[("active", BG_PRIMARY)])
+
+    style.configure(
+        "TProgressbar",
+        troughcolor=BG_SECONDARY,
+        background=ACCENT,
+        bordercolor=BORDER,
+        lightcolor=ACCENT,
+        darkcolor=ACCENT,
+    )
+
+    return style
+
+
+def apply_hyprland_theme(root: tk.Misc) -> ttk.Style:
+    """Apply a dark, modern, Hyprland-inspired look to Tk/ttk widgets."""
+    try:
+        root.configure(bg=BG_PRIMARY)
+    except tk.TclError:
+        pass
+
+    _configure_classic_tk_defaults(root)
+    return _configure_ttk_styles(root)

--- a/gui/theme.py
+++ b/gui/theme.py
@@ -32,10 +32,14 @@ def _configure_classic_tk_defaults(root: tk.Misc) -> None:
     root.option_add("*Text.InsertBackground", TEXT_PRIMARY)
 
     # Buttons and checkboxes
-    root.option_add("*Button.Background", BG_ELEVATED)
-    root.option_add("*Button.Foreground", TEXT_PRIMARY)
-    root.option_add("*Button.ActiveBackground", BORDER)
-    root.option_add("*Button.ActiveForeground", TEXT_PRIMARY)
+    root.option_add("*Button.Background", ACCENT)
+    root.option_add("*Button.Foreground", BG_PRIMARY)
+    root.option_add("*Button.ActiveBackground", ACCENT_ACTIVE)
+    root.option_add("*Button.ActiveForeground", BG_PRIMARY)
+    root.option_add("*Menubutton.Background", ACCENT)
+    root.option_add("*Menubutton.Foreground", BG_PRIMARY)
+    root.option_add("*Menubutton.ActiveBackground", ACCENT_ACTIVE)
+    root.option_add("*Menubutton.ActiveForeground", BG_PRIMARY)
 
     root.option_add("*Checkbutton.Background", BG_PRIMARY)
     root.option_add("*Checkbutton.Foreground", TEXT_PRIMARY)
@@ -64,7 +68,9 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
     style = ttk.Style(root)
     default_font, header_font, muted_font, primary_button_font = _build_theme_fonts(root)
 
-    preferred_themes = ("vista", "clam", "alt", "default")
+    # Native Windows themes like "vista" ignore most custom button colors.
+    # Prefer a fully styleable ttk theme so the dark palette renders consistently.
+    preferred_themes = ("clam", "alt", "default", "vista")
     available = style.theme_names()
     for theme in preferred_themes:
         if theme in available:
@@ -82,6 +88,18 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
 
     style.configure("App.TFrame", background=BG_PRIMARY)
     style.configure("Card.TFrame", background=BG_ELEVATED, relief="flat")
+    style.configure(
+        "Card.Header.TLabel",
+        background=BG_ELEVATED,
+        foreground=TEXT_PRIMARY,
+        font=header_font,
+    )
+    style.configure(
+        "Card.Muted.TLabel",
+        background=BG_ELEVATED,
+        foreground=TEXT_MUTED,
+        font=muted_font,
+    )
 
     style.configure(
         "Header.TLabel",
@@ -98,15 +116,21 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
 
     style.configure(
         "TButton",
-        background=BG_ELEVATED,
-        foreground=TEXT_PRIMARY,
+        background=ACCENT,
+        foreground=BG_PRIMARY,
         padding=8,
         relief="flat",
         borderwidth=0,
+        focuscolor=BG_PRIMARY,
+        font=primary_button_font,
     )
     style.map(
         "TButton",
-        background=[("active", BORDER), ("pressed", BORDER)],
+        background=[
+            ("disabled", BG_SECONDARY),
+            ("active", ACCENT_ACTIVE),
+            ("pressed", ACCENT_ACTIVE),
+        ],
         foreground=[("disabled", TEXT_MUTED)],
     )
 
@@ -118,15 +142,24 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
         relief="flat",
         borderwidth=0,
         font=primary_button_font,
+        focuscolor=BG_PRIMARY,
     )
     style.map(
         "Primary.TButton",
-        background=[("active", ACCENT_ACTIVE), ("pressed", ACCENT_ACTIVE)],
+        background=[
+            ("disabled", BG_SECONDARY),
+            ("active", ACCENT_ACTIVE),
+            ("pressed", ACCENT_ACTIVE),
+        ],
         foreground=[("disabled", TEXT_MUTED)],
     )
 
-    style.configure("TMenubutton", background=BG_ELEVATED, foreground=TEXT_PRIMARY)
-    style.map("TMenubutton", background=[("active", BORDER)])
+    style.configure("TMenubutton", background=ACCENT, foreground=BG_PRIMARY)
+    style.map(
+        "TMenubutton",
+        background=[("disabled", BG_SECONDARY), ("active", ACCENT_ACTIVE)],
+        foreground=[("disabled", TEXT_MUTED)],
+    )
 
     style.configure(
         "TCheckbutton",
@@ -134,6 +167,12 @@ def _configure_ttk_styles(root: tk.Misc) -> ttk.Style:
         foreground=TEXT_PRIMARY,
     )
     style.map("TCheckbutton", background=[("active", BG_PRIMARY)])
+    style.configure(
+        "Card.TCheckbutton",
+        background=BG_ELEVATED,
+        foreground=TEXT_PRIMARY,
+    )
+    style.map("Card.TCheckbutton", background=[("active", BG_ELEVATED)])
 
     style.configure(
         "TProgressbar",

--- a/vendor/tkhtmlview/__init__.py
+++ b/vendor/tkhtmlview/__init__.py
@@ -168,7 +168,7 @@ class HTMLScrolledText(scrolledtext.ScrolledText):
 
     # -- Tag configuration ------------------------------------------------
     def _configure_tags(self) -> None:
-        base_font = tkfont.nametofont(self.cget("font")).copy()
+        base_font = self._resolve_base_font()
 
         bold_font = base_font.copy()
         bold_font.configure(weight="bold")
@@ -212,6 +212,13 @@ class HTMLScrolledText(scrolledtext.ScrolledText):
         self.raw_markdown = ""
 
 # -- Internal helpers ------------------------------------------------
+    def _resolve_base_font(self) -> tkfont.Font:
+        font_value = self.cget("font")
+        try:
+            return tkfont.nametofont(font_value).copy()
+        except tk.TclError:
+            return tkfont.Font(font=font_value).copy()
+
     def _register_link_tag(self, tag_name: str, href: str) -> None:
         self._link_tags[tag_name] = href
         self.tag_configure(tag_name, foreground="#0645AD", underline=True)


### PR DESCRIPTION
### Motivation
- Provide a consistent modern dark theme for the application by centralising palette and ttk styles in a single module (`gui/theme.py`).
- Migrate legacy `tk` widgets to `ttk` variants to enable theming and a more cohesive look across windows.
- Improve layout space by increasing default window sizes for the main and invoice windows (`800x960` -> `900x980`).

### Description
- Introduce `gui/theme.py` which defines a Hyprland-inspired dark palette and the `apply_hyprland_theme` function that configures classic `tk` defaults and `ttk` styles. 
- Apply the theme via `apply_hyprland_theme` in `create_main_window` and `create_invoice_window` to set root background and register the ttk style set. 
- Replace many `tk` widget usages with `ttk` equivalents and adopt new styles such as `App.TFrame`, `Card.TFrame`, `Header.TLabel`, `Muted.TLabel`, and `Primary.TButton` to standardise appearance and spacing. 
- Adjusted main and invoice window geometries from `800x960` to `900x980` and tuned paddings on several frames to better fit the updated layout.

### Testing
- No automated tests were run for these UI and styling changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21239b47c83268a8b08315891effb)